### PR TITLE
Fix tabs clearing search filters

### DIFF
--- a/src/router/modules/approval.ts
+++ b/src/router/modules/approval.ts
@@ -15,7 +15,8 @@ export default {
       name: "ApprovalList",
       component: () => import("@/views/search-management/index.vue"),
       meta: {
-        title: $t("approval.list")
+        title: $t("approval.list"),
+        keepAlive: true
       }
     },
     {

--- a/src/router/modules/contact.ts
+++ b/src/router/modules/contact.ts
@@ -15,7 +15,8 @@ export default {
       name: "ContactList",
       component: () => import("@/views/search-management/index.vue"),
       meta: {
-        title: $t("menus.dimercoContact")
+        title: $t("menus.dimercoContact"),
+        keepAlive: true
       }
     },
     {

--- a/src/router/modules/customer.ts
+++ b/src/router/modules/customer.ts
@@ -15,7 +15,8 @@ export default {
       name: "CustomerList",
       component: () => import("@/views/search-management/index.vue"),
       meta: {
-        title: $t("menus.dimercoCustomer")
+        title: $t("menus.dimercoCustomer"),
+        keepAlive: true
       }
     },
     {

--- a/src/router/modules/tasks.ts
+++ b/src/router/modules/tasks.ts
@@ -15,7 +15,8 @@ export default {
       name: "TaskList",
       component: () => import("@/views/search-management/index.vue"),
       meta: {
-        title: $t("menus.dimercoTask")
+        title: $t("menus.dimercoTask"),
+        keepAlive: true
       }
     },
     {


### PR DESCRIPTION
## Summary
- keep search pages alive so that filters persist across tab switches

## Testing
- `pnpm lint:eslint` *(fails: unable to reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685418993e188320bebfb3cb44992591