### PR TITLE
Fix tabs clearing search filters

### DIFF
--- a/src/router/modules/approval.ts
+++ b/src/router/modules/approval.ts
@@ -16,7 +16,8 @@ export default {
       component: () => import("@/views/search-management/index.vue"),
       meta: {
         title: $t("approval.list"),
-        keepAlive: true
+        keepAlive: true,
+        componentName: "searchManagement"
       }
     },
     {

--- a/src/router/modules/contact.ts
+++ b/src/router/modules/contact.ts
@@ -16,7 +16,8 @@ export default {
       component: () => import("@/views/search-management/index.vue"),
       meta: {
         title: $t("menus.dimercoContact"),
-        keepAlive: true
+        keepAlive: true,
+        componentName: "searchManagement"
       }
     },
     {

--- a/src/router/modules/customer.ts
+++ b/src/router/modules/customer.ts
@@ -16,7 +16,8 @@ export default {
       component: () => import("@/views/search-management/index.vue"),
       meta: {
         title: $t("menus.dimercoCustomer"),
-        keepAlive: true
+        keepAlive: true,
+        componentName: "searchManagement"
       }
     },
     {

--- a/src/router/modules/deal.ts
+++ b/src/router/modules/deal.ts
@@ -18,7 +18,8 @@ export default {
       component: () => import("@/views/search-management/index.vue"),
       meta: {
         title: $t("menus.dimercoDeal"),
-        keepAlive: true
+        keepAlive: true,
+        componentName: "searchManagement"
       }
     },
     {

--- a/src/router/modules/quotes.ts
+++ b/src/router/modules/quotes.ts
@@ -16,7 +16,8 @@ export default {
       component: () => import("@/views/search-management/index.vue"),
       meta: {
         title: $t("menus.dimercoQuotes"),
-        keepAlive: true
+        keepAlive: true,
+        componentName: "searchManagement"
       }
     },
     {

--- a/src/router/modules/tasks.ts
+++ b/src/router/modules/tasks.ts
@@ -16,7 +16,8 @@ export default {
       component: () => import("@/views/search-management/index.vue"),
       meta: {
         title: $t("menus.dimercoTask"),
-        keepAlive: true
+        keepAlive: true,
+        componentName: "searchManagement"
       }
     },
     {

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -264,36 +264,22 @@ function formatTwoStageRoutes(routesList: RouteRecordRaw[]) {
 }
 
 /** 处理缓存路由（添加、删除、刷新） */
-function handleAliveRoute({ name }: ToRouteType, mode?: string) {
+function handleAliveRoute(route: ToRouteType, mode?: string) {
+  const name = (route.meta && route.meta.componentName) || route.name;
   switch (mode) {
     case "add":
-      usePermissionStoreHook().cacheOperate({
-        mode: "add",
-        name
-      });
+      usePermissionStoreHook().cacheOperate({ mode: "add", name });
       break;
     case "delete":
-      usePermissionStoreHook().cacheOperate({
-        mode: "delete",
-        name
-      });
+      usePermissionStoreHook().cacheOperate({ mode: "delete", name });
       break;
     case "refresh":
-      usePermissionStoreHook().cacheOperate({
-        mode: "refresh",
-        name
-      });
+      usePermissionStoreHook().cacheOperate({ mode: "refresh", name });
       break;
     default:
-      usePermissionStoreHook().cacheOperate({
-        mode: "delete",
-        name
-      });
+      usePermissionStoreHook().cacheOperate({ mode: "delete", name });
       useTimeoutFn(() => {
-        usePermissionStoreHook().cacheOperate({
-          mode: "add",
-          name
-        });
+        usePermissionStoreHook().cacheOperate({ mode: "add", name });
       }, 100);
   }
 }


### PR DESCRIPTION
## Summary
- update router util to use component name for keepAlive
- add componentName meta to search pages

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685507cd60e8832084231a0ab5b1af8c