### PR TITLE
Fix contact search caching

### DIFF
--- a/src/router/modules/approval.ts
+++ b/src/router/modules/approval.ts
@@ -13,11 +13,12 @@ export default {
     {
       path: "/approval/index",
       name: "ApprovalList",
-      component: () => import("@/views/search-management/index.vue"),
+      component: () =>
+        import("@/views/search-management/wrappers/ApprovalList.vue"),
       meta: {
         title: $t("approval.list"),
         keepAlive: true,
-        componentName: "searchManagement"
+        componentName: "ApprovalListPage"
       }
     },
     {

--- a/src/router/modules/contact.ts
+++ b/src/router/modules/contact.ts
@@ -13,11 +13,12 @@ export default {
     {
       path: "/contact/index",
       name: "ContactList",
-      component: () => import("@/views/search-management/index.vue"),
+      component: () =>
+        import("@/views/search-management/wrappers/ContactList.vue"),
       meta: {
         title: $t("menus.dimercoContact"),
         keepAlive: true,
-        componentName: "searchManagement"
+        componentName: "ContactListPage"
       }
     },
     {

--- a/src/router/modules/customer.ts
+++ b/src/router/modules/customer.ts
@@ -13,11 +13,12 @@ export default {
     {
       path: "/customer/index",
       name: "CustomerList",
-      component: () => import("@/views/search-management/index.vue"),
+      component: () =>
+        import("@/views/search-management/wrappers/CustomerList.vue"),
       meta: {
         title: $t("menus.dimercoCustomer"),
         keepAlive: true,
-        componentName: "searchManagement"
+        componentName: "CustomerListPage"
       }
     },
     {

--- a/src/router/modules/deal.ts
+++ b/src/router/modules/deal.ts
@@ -15,11 +15,12 @@ export default {
     {
       path: "/deal/index",
       name: "dealSearch",
-      component: () => import("@/views/search-management/index.vue"),
+      component: () =>
+        import("@/views/search-management/wrappers/DealSearch.vue"),
       meta: {
         title: $t("menus.dimercoDeal"),
         keepAlive: true,
-        componentName: "searchManagement"
+        componentName: "DealSearchPage"
       }
     },
     {

--- a/src/router/modules/quotes.ts
+++ b/src/router/modules/quotes.ts
@@ -13,11 +13,12 @@ export default {
     {
       path: "/quotes/index",
       name: "quoteSearch",
-      component: () => import("@/views/search-management/index.vue"),
+      component: () =>
+        import("@/views/search-management/wrappers/QuoteSearch.vue"),
       meta: {
         title: $t("menus.dimercoQuotes"),
         keepAlive: true,
-        componentName: "searchManagement"
+        componentName: "QuoteSearchPage"
       }
     },
     {

--- a/src/router/modules/tasks.ts
+++ b/src/router/modules/tasks.ts
@@ -13,11 +13,12 @@ export default {
     {
       path: "/tasks/index",
       name: "TaskList",
-      component: () => import("@/views/search-management/index.vue"),
+      component: () =>
+        import("@/views/search-management/wrappers/TaskList.vue"),
       meta: {
         title: $t("menus.dimercoTask"),
         keepAlive: true,
-        componentName: "searchManagement"
+        componentName: "TaskListPage"
       }
     },
     {

--- a/src/views/search-management/wrappers/ApprovalList.vue
+++ b/src/views/search-management/wrappers/ApprovalList.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import SearchManagement from "../index.vue";
+
+defineOptions({ name: "ApprovalListPage" });
+</script>
+
+<template>
+  <SearchManagement />
+</template>

--- a/src/views/search-management/wrappers/ContactList.vue
+++ b/src/views/search-management/wrappers/ContactList.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import SearchManagement from "../index.vue";
+
+// unique name for keep-alive
+defineOptions({ name: "ContactListPage" });
+</script>
+
+<template>
+  <SearchManagement />
+</template>

--- a/src/views/search-management/wrappers/CustomerList.vue
+++ b/src/views/search-management/wrappers/CustomerList.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import SearchManagement from "../index.vue";
+
+defineOptions({ name: "CustomerListPage" });
+</script>
+
+<template>
+  <SearchManagement />
+</template>

--- a/src/views/search-management/wrappers/DealSearch.vue
+++ b/src/views/search-management/wrappers/DealSearch.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import SearchManagement from "../index.vue";
+
+defineOptions({ name: "DealSearchPage" });
+</script>
+
+<template>
+  <SearchManagement />
+</template>

--- a/src/views/search-management/wrappers/QuoteSearch.vue
+++ b/src/views/search-management/wrappers/QuoteSearch.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import SearchManagement from "../index.vue";
+
+defineOptions({ name: "QuoteSearchPage" });
+</script>
+
+<template>
+  <SearchManagement />
+</template>

--- a/src/views/search-management/wrappers/TaskList.vue
+++ b/src/views/search-management/wrappers/TaskList.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import SearchManagement from "../index.vue";
+
+defineOptions({ name: "TaskListPage" });
+</script>
+
+<template>
+  <SearchManagement />
+</template>


### PR DESCRIPTION
## Summary
- add wrapper components for `search-management` to give each route its own `keep-alive` cache
- reference new wrappers from contact/customer/task/quote/approval/deal routes

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6855153ed9048320935447c84fffbee3